### PR TITLE
Add assertions to vet repository caching tests

### DIFF
--- a/src/test/java/org/springframework/samples/petclinic/MySqlIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/MySqlIntegrationTests.java
@@ -57,11 +57,12 @@ class MySqlIntegrationTests {
 	@Autowired
 	private RestTemplateBuilder builder;
 
-	@Test
-	void testFindAll() throws Exception {
-		vets.findAll();
-		vets.findAll(); // served from cache
-	}
+        @Test
+        void testFindAll() throws Exception {
+                Iterable<?> veterinarians = vets.findAll();
+                assertThat(veterinarians).isNotEmpty();
+                vets.findAll(); // served from cache
+        }
 
 	@Test
 	void testOwnerDetails() {

--- a/src/test/java/org/springframework/samples/petclinic/PetClinicIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/PetClinicIntegrationTests.java
@@ -43,11 +43,12 @@ public class PetClinicIntegrationTests {
 	@Autowired
 	private RestTemplateBuilder builder;
 
-	@Test
-	void testFindAll() throws Exception {
-		vets.findAll();
-		vets.findAll(); // served from cache
-	}
+        @Test
+        void testFindAll() throws Exception {
+                Iterable<?> veterinarians = vets.findAll();
+                assertThat(veterinarians).isNotEmpty();
+                vets.findAll(); // served from cache
+        }
 
 	@Test
 	void testOwnerDetails() {

--- a/src/test/java/org/springframework/samples/petclinic/PostgresIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/PostgresIntegrationTests.java
@@ -77,11 +77,12 @@ public class PostgresIntegrationTests {
 			.run(args);
 	}
 
-	@Test
-	void testFindAll() throws Exception {
-		vets.findAll();
-		vets.findAll(); // served from cache
-	}
+        @Test
+        void testFindAll() throws Exception {
+                Iterable<?> veterinarians = vets.findAll();
+                assertThat(veterinarians).isNotEmpty();
+                vets.findAll(); // served from cache
+        }
 
 	@Test
 	void testOwnerDetails() {


### PR DESCRIPTION
## Summary
- capture the results of `vets.findAll()` in integration tests
- assert that the returned veterinarian collection is not empty before verifying the cache call

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc7cead69c832ba07100d6bdb27dda